### PR TITLE
metrics-server: try replacing helm with kustomize

### DIFF
--- a/metrics-server/.gitignore
+++ b/metrics-server/.gitignore
@@ -1,0 +1,1 @@
+metrics-server

--- a/metrics-server/deployment.yaml
+++ b/metrics-server/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: metrics-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: metrics-server
+        command:
+          - /metrics-server
+          - --cert-dir=/tmp
+          - --logtostderr
+          - --secure-port=8443
+          - --kubelet-preferred-address-types=InternalIP
+          - --kubelet-insecure-tls
+        ports:
+          - containerPort: 8443
+            name: https
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 20
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["all"]
+          readOnlyRootFilesystem: true
+          runAsGroup: 10001
+          runAsNonRoot: true
+          runAsUser: 10001

--- a/metrics-server/kustomization.yaml
+++ b/metrics-server/kustomization.yaml
@@ -1,0 +1,13 @@
+commonLabels:
+  variant: test
+resources:
+  - metrics-server/deploy/1.8+/aggregated-metrics-reader.yaml
+  - metrics-server/deploy/1.8+/metrics-apiservice.yaml
+  - metrics-server/deploy/1.8+/metrics-server-deployment.yaml
+  - metrics-server/deploy/1.8+/metrics-server-service.yaml
+
+  - metrics-server/deploy/1.8+/auth-delegator.yaml
+  - metrics-server/deploy/1.8+/auth-reader.yaml
+  - metrics-server/deploy/1.8+/resource-reader.yaml
+patches:
+  - deployment.yaml

--- a/metrics-server/script/up
+++ b/metrics-server/script/up
@@ -25,7 +25,6 @@ git -C metrics-server \
 # Install metrics-server
 NAMESPACE=kube-system
 echo "Install metrics-server via kustomize + kubectl"
-#helm upgrade metrics-server --install --namespace ${NAMESPACE} -f ../metrics-server/values.yaml stable/metrics-server
 kubectl kustomize . | kubectl apply -f -
 
 echo "Waiting for pods to be Ready"

--- a/metrics-server/script/up
+++ b/metrics-server/script/up
@@ -15,16 +15,19 @@ CLUSTER_NAME=${1:-metrics-demo}
 # Grab the cluster kubeconfig.
 export KUBECONFIG="tmp/${CLUSTER_NAME}-kubeconfig.yaml"
 
-# Install Helm/tiller and wait for it to be Ready.
-(
-    cd ../helm
-    script/up ${CLUSTER_NAME}
-)
+git clone https://github.com/kubernetes-incubator/metrics-server \
+  || true
+
+# update to metrics-server upstream master at the time this script was updated
+git -C metrics-server \
+  reset --hard ad1de3e56d98f25dc436ba08a6097d44375c8bc6
 
 # Install metrics-server
-NAMESPACE="metrics"
-echo "Install metrics-server via Helm"
-helm upgrade metrics-server --install --namespace ${NAMESPACE} -f ../metrics-server/values.yaml stable/metrics-server
+NAMESPACE=kube-system
+echo "Install metrics-server via kustomize + kubectl"
+#helm upgrade metrics-server --install --namespace ${NAMESPACE} -f ../metrics-server/values.yaml stable/metrics-server
+kubectl kustomize . | kubectl apply -f -
+
 echo "Waiting for pods to be Ready"
-kubectl wait --for=condition=Ready pods -l "release=metrics-server" -n ${NAMESPACE} --timeout=120s
+kubectl wait --for=condition=Ready pods -l "k8s-app=metrics-server" -n ${NAMESPACE} --timeout=120s
 echo "🎉"

--- a/metrics-server/values.yaml
+++ b/metrics-server/values.yaml
@@ -1,5 +1,0 @@
-args:
-  # DOKS currently doesn't resolve node names from within cluster workloads.
-  - --kubelet-preferred-address-types=InternalIP
-  # DOKS currently has self-signed kubelet internal serving certificates.
-  - --kubelet-insecure-tls


### PR DESCRIPTION
This PR proposes the use of the kustomize included in `kubectl` instead of the third-party `helm` to deploy metrics-server.

The way this works is roughly:

1. create a DOKS cluster (just like before)
1. clone `kubernetes-incubator/metrics-server` at a specific git ref
1. call `kubectl kustomize` in the `metrics-server` directory
  * this makes use of the `kustomization.yaml` file in the `metrics-server` directory
  * the `kustomization.yaml` file points at example deployment manifests in the cloned `kubernetes-incubator/metrics-server` directory
  * the `kustomization.yaml` patches the upstream example deployment manifests with settings similar to what came with the `helm` chart
1. just like before, wait until the `metrics-server` pod(s) are ready

One major difference from the `helm` chart is that with `helm` it was easy to deploy `metrics-server` to its own namespace whereas the upstream example manifests on which the `kustomize` approach is based assume deployment in `kube-system`. It wasn't straightforward to use `kustomize` patches or bases to do something similar -- I'm sure it's possible, I just haven't found the minimal set of patches necessary yet.