### PR TITLE
Use 'latest' DOKS version by default and in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,15 @@
 language: go
 
 env:
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=terraform
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=network-policy
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=monitoring
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=istio
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=local-pv
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=hpa
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=vpa
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=kubedb
-  - CLUSTER_VERSION=1.14.1-do.4
-    EXAMPLE=xfs
+  - EXAMPLE=terraform
+  - EXAMPLE=network-policy
+  - EXAMPLE=monitoring
+  - EXAMPLE=istio
+  - EXAMPLE=local-pv
+  - EXAMPLE=hpa
+  - EXAMPLE=vpa
+  - EXAMPLE=kubedb
+  - EXAMPLE=xfs
 
 before_script:
   - go get -u github.com/digitalocean/doctl/cmd/doctl
@@ -31,7 +22,7 @@ script:
   - cd $EXAMPLE && script/test
 
 branches:
-  only: 
+  only:
     - master
 
 notifications:

--- a/script/create-cluster
+++ b/script/create-cluster
@@ -13,7 +13,7 @@ NAME="${1}"
 REGION="${REGION:-sfo2}"
 NODE_SIZE="${NODE_SIZE:-s-1vcpu-2gb}"
 NODE_COUNT="${NODE_COUNT:-2}"
-VERSION="${CLUSTER_VERSION:-1.14.2-do.0}"
+VERSION="${CLUSTER_VERSION:-latest}"
 
 # Retries a command on failure.
 # $1 - the max number of attempts


### PR DESCRIPTION
Since we unpublish DOKS versions when publishing new ones, and (if I understand correctly) we are hoping to make it easier to release new versions more often, the default and CI CLUSTER_VERSION settings up to date is going to become a maintenance burden for this repo. Instead, let's just always use `latest` both by default and in CI.